### PR TITLE
bug fix

### DIFF
--- a/irispy/spectrograph.py
+++ b/irispy/spectrograph.py
@@ -26,6 +26,7 @@ class IRISSpectrograph(object):
         raster_index_to_file = []
         for f, filename in enumerate(filenames):
             hdulist = fits.open(filename)
+            hdulist.verify('fix')
             if f == 0:
                 # collecting the window observations.
                 windows_in_obs = np.array([hdulist[0].header["TDESC{0}".format(i)]


### PR DESCRIPTION
```
In [4]: sg = IRISSpectrograph('iris_l2_20161020_052416_3893010094_raster_t000_r00000.fits')
---------------------------------------------------------------------------
VerifyError                               Traceback (most recent call last)
<ipython-input-4-cbe8b1f01534> in <module>()
----> 1 sg = IRISSpectrograph('iris_l2_20161020_052416_3893010094_raster_t000_r00000.fits')

~/sunpy_dev/irispy/irispy/spectrograph.py in __init__(self, filenames, spectral_windows, common_axis)
     73                 # appending Cube instance to the corresponding window key in dictionary's list.
     74                 data_dict[window_name].append(
---> 75                     Cube(data_nan_masked, wcs_, meta=dict(self.meta), mask=data_mask))
     76 
     77             scan_label = "scan{0}".format(f)

~/anaconda3/envs/irispy-dev/lib/python3.6/site-packages/astropy/io/fits/header.py in __getitem__(self, key)
    153             # the raw value, not the parsed out float value
    154             return card.rawvalue
--> 155         return card.value
    156 
    157     def __setitem__(self, key, value):

~/anaconda3/envs/irispy-dev/lib/python3.6/site-packages/astropy/io/fits/card.py in value(self)
    281             value = self._value
    282         elif self._valuestring is not None or self._image:
--> 283             self._value = self._parse_value()
    284             value = self._value
    285         else:

~/anaconda3/envs/irispy-dev/lib/python3.6/site-packages/astropy/io/fits/card.py in _parse_value(self)
    740         if m is None:
    741             raise VerifyError("Unparsable card ({}), fix it first with "
--> 742                               ".verify('fix').".format(self.keyword))
    743 
    744         if m.group('bool') is not None:

VerifyError: Unparsable card (CADPL_DV), fix it first with .verify('fix').
```



Bug Fix :)
@DanRyanIrish 