### PR TITLE
Update initialization of NDCube in IRISSpectrograph

### DIFF
--- a/irispy/spectrogram.py
+++ b/irispy/spectrogram.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 # Author: Daniel Ryan <ryand5@tcd.ie>
 
-#from collections import namedtuple
-
 import astropy.units as u
 from ndcube import NDCubeSequence
 import ndcube.cube_utils as cu
@@ -33,8 +31,9 @@ class SpectrogramSequence(NDCubeSequence):
 
     @property
     def dimensions(self):
-        return SequenceDimensionPair(shape=tuple(
-            [int(sum([d.dimensions.shape[0].value for d in self.data]))]+list(self.data[0].dimensions.shape[1::])),
+        return SequenceDimensionPair(
+            shape=tuple([int(sum([d.dimensions.shape[0].value for d in self.data]))] + \
+                        list(self.data[0].dimensions.shape[1::])),
             axis_types=tuple(self.data[0].dimensions.axis_types))
 
     def axes_to_world(self, origin=0):

--- a/irispy/spectrograph.py
+++ b/irispy/spectrograph.py
@@ -101,7 +101,7 @@ class IRISSpectrograph(object):
                 data_mask = hdulist[window_fits_indices[i]].data == -200.
                 # appending NDCube instance to the corresponding window key in dictionary's list.
                 data_dict[window_name].append(
-                    NDCube(data_nan_masked, wcs=wcs_, meta=dict(self.meta), mask=data_mask, extra_coords=extra_coords))
+                    NDCube(data_nan_masked, wcs_, meta=dict(self.meta), mask=data_mask, extra_coords=extra_coords))
 
             scan_label = "scan{0}".format(f)
             # Append to list representing the scan labels of each


### PR DESCRIPTION
NDCube package was updated so wcs is a required arg, and an optional kwarg.  This PR updates the initialization of NDCubes in IRISSpectrograph in accordance with this update.  Also a PEP8 change to SpectrogramSequence.