### PR TITLE
IRISSpectrorgraph Metadata PR

### DIFF
--- a/irispy/spectrograph.py
+++ b/irispy/spectrograph.py
@@ -195,14 +195,3 @@ class IRISSpectrograph(object):
             if type(self.data[key]) == SpectrogramSequence:
                 spectral_window_list.append([self.data[key].meta[colname] for colname in colnames])
         return Table(rows=spectral_window_list, names=colnames)
-
-def _enter_column_into_table_as_quantity(header_property_name, header, header_colnames,
-                                         data, unit):
-    """Used in initiation of IRISSpectrograph to convert auxiliary data to Quantities."""
-    index = np.where(np.array(header_colnames) == header_property_name)[0]
-    if len(index) == 1:
-        index = index[0]
-    else:
-        raise ValueError("Multiple property names equal to {0}".format(header_property_name))
-    pop_colname = header_colnames.pop(index)
-    return u.Quantity(data[:, header[pop_colname]], unit=unit)

--- a/irispy/spectrograph.py
+++ b/irispy/spectrograph.py
@@ -86,6 +86,8 @@ class IRISSpectrograph(object):
                              "SUMSPTRN": hdulist[0].header["SUMSPTRN"],
                              "SUMSPTRF": hdulist[0].header["SUMSPTRF"],
                              "SUMSPAT": hdulist[0].header["SUMSPAT"],
+                             "NEXPOBS": hdulist[0].header["NEXPOBS"],
+                             "NRASTERP": hdulist[0].header["NRASTERP"],
                              "KEYWDDOC": hdulist[0].header["KEYWDDOC"]}
                 # Initialize meta dictionary for each spectral_window
                 window_metas = {}


### PR DESCRIPTION
This PR adjusts the way in which the metadata in ```IRISSpectrograph``` is stored and presented in the following ways:
1. ```IRISSpectrograph.meta``` was previously the primary header of the first FITS file read into the object.  This has been changed to a dictionary containing some properties from that header general to the OBS from which the observations come.
2. Metadata from the primary FITS header that is specific to the raster or file from which the dta comes has been moved into the meta objects of the ```NDCube```s objects that take the data cubes from each file.  This leads to some duplication of metadata across the spectral windows' ```NDCube```s.  However, it makes the data from each spectral windows more self-contained.
2.  The values of the columns in the ```IRISSpectrograph.spectral_windows``` have bee moved out of that attribute and into the ```IRISSpectrograph.data``` ```SpectrogramSequence```s' meta attributes.  
3. The static ```IRISSpectrograph.spectral_windows``` table has been replaced with a dynamic property that generates the table on the fly from the entries in the ```IRISSpectrograph.data``` meta dictionaries. 
5. Some data from the auxiliary FITS extension giving relevant data for each exposure has been included in the ```_extra_coords``` attributes of the ```NDCube```s of each spectral window.  As with point 2, this leads to a little data duplication but makes ```SpectrogramSequence```s for each spectral window self-contained.