### PR TITLE
IRISSpectrogramSequence

### DIFF
--- a/irispy/iris_tools.py
+++ b/irispy/iris_tools.py
@@ -472,3 +472,15 @@ def _calculate_orbital_wavelength_variation(data_array, date_data_created, slit_
     orbital_wavelength_variation = Table([times, dw_orb_fuv, dw_orb_nuv],
                                          names=("time", "wavelength variation FUV", "wavelength variation NUV"))
     return orbital_wavelength_variation
+
+def _get_detector_type(meta):
+    """Gets the IRIS detector type from a meta dictionary.
+
+    In this function, FUV1 and FUV2 are just assigned as FUV.
+
+    """
+    if "FUV" in meta["detector type"]:
+        detector_type = "FUV"
+    else:
+        detector_type = meta["detector type"]
+    return detector_type

--- a/irispy/iris_tools.py
+++ b/irispy/iris_tools.py
@@ -21,8 +21,12 @@ from sunpy.time import parse_time
 # paper.
 DETECTOR_GAIN = {"NUV": 18., "FUV": 6., "SJI": 18.}
 DETECTOR_YIELD = {"NUV": 1., "FUV": 1.5, "SJI": 1.}
-READOUT_NOISE = {"NUV": {"value": 1.2, "unit": "DN"}, "FUV": {"value": 3.1, "unit": "DN"},
-                 "SJI": {"value": 1.2, "unit": "DN"}}
+DN_UNIT = {
+    "NUV": u.def_unit("DN_IRIS_NUV", DETECTOR_GAIN["NUV"]/DETECTOR_YIELD["NUV"]*u.ct),
+    "FUV": u.def_unit("DN_IRIS_FUV", DETECTOR_GAIN["FUV"]/DETECTOR_YIELD["FUV"]*u.ct),
+    "SJI": u.def_unit("DN_IRIS_SJI", DETECTOR_GAIN["SJI"]/DETECTOR_YIELD["SJI"]*u.ct)}
+READOUT_NOISE = {"NUV": 1.2*DN_UNIT["NUV"], "FUV": 3.1*DN_UNIT["FUV"],
+                 "SJI": 1.2*DN_UNIT["SJI"]}
 
 # Define whether IRIS WCS is 0 or 1 origin based.
 WCS_ORIGIN = 1

--- a/irispy/spectrogram.py
+++ b/irispy/spectrogram.py
@@ -157,7 +157,7 @@ def _convert_iris_sequence(sequence, new_unit):
         if new_unit == "DN":
             new_unit = iris_tools.DN_UNIT[detector_type]
         # If NDCube is already in new unit, add NDCube as is to list.
-        if cube.unit == new_unit or cube.unit == new_unit / u.s:
+        if cube.unit is new_unit or cube.unit is new_unit / u.s:
             converted_data_list.append(cube)
         # Else convert data and uncertainty to new unit.
         if cube.unit != new_unit or cube.unit != new_unit / u.s:

--- a/irispy/spectrogram.py
+++ b/irispy/spectrogram.py
@@ -12,7 +12,30 @@ from irispy import iris_tools
 __all__ = ['SpectrogramSequence']
 
 class SpectrogramSequence(NDCubeSequence):
-    """docstring for SpectrogramSequence"""
+    """Class for holding, slicing and plotting spectrogram data.
+
+    Parameters
+    ----------
+    data_list: `list`
+        List of `ndcube.NDCube` objects holding data.
+
+    common_axis: `int`
+        The axis of the NDCubes corresponding to time.
+
+    raster_positions_per_scan: `int`
+        Number of slit positions per raster scan.
+
+    first_exposure_raster_position: `int`
+        The slit position of the first exposure in the data assuming zero-based counting.
+        For example, a raster scan goes from left to right.  The right most position
+        is designated 0.  But the data does not include the first 3 (0, 1, 2) raster
+        positions in the first scan.  Therefore this variable should be set to 3.
+        This enables partial raster scans to be stored in the object.
+
+    meta: `dict` or header object
+        Metadata associated with the sequence.
+
+    """
 
     def __init__(self, data_list, common_axis, raster_positions_per_scan,
                  first_exposure_raster_position, meta=None):
@@ -76,10 +99,36 @@ class _IndexByRasterSlicer(object):
         return cu.get_cube_from_sequence(self.seq, item)
 
 class IRISSpectrogramSequence(SpectrogramSequence):
-    """A SpectrogramSequence for IRIS data including additional functionalities."""
+    """Class for holding, slicing and plotting IRIS spectrogram data.
+
+    This class contains all the functionality of its super class with
+    some additional functionalities.
+
+    Parameters
+    ----------
+    data_list: `list`
+        List of `ndcube.NDCube` objects holding data.
+
+    common_axis: `int`
+        The axis of the NDCubes corresponding to time.
+
+    raster_positions_per_scan: `int`
+        Number of slit positions per raster scan.
+
+    first_exposure_raster_position: `int`
+        The slit position of the first exposure in the data assuming zero-based counting.
+        For example, a raster scan goes from left to right.  The right most position
+        is designated 0.  But the data does not include the first 3 (0, 1, 2) raster
+        positions in the first scan.  Therefore this variable should be set to 3.
+        This enables partial raster scans to be stored in the object.
+
+    meta: `dict` or header object
+        Metadata associated with the sequence.
+
+    """
 
     def to_counts(self, copy=False):
-        """Converts data and uncertainty to photon count units.
+        """Converts data and uncertainty attributes to photon count units.
 
         Parameters
         ----------
@@ -90,7 +139,7 @@ class IRISSpectrogramSequence(SpectrogramSequence):
 
         """
         converted_data_list = _convert_iris_sequence(self, u.ct)
-        if copy:
+        if copy is True:
             return IRISSpectrogramSequence(
                 converted_data_list, self._common_axis, self.raster_positions_per_scan,
                 self.first_exposure_raster_position, meta=self.meta)
@@ -98,7 +147,7 @@ class IRISSpectrogramSequence(SpectrogramSequence):
             self.data = converted_data_list
 
     def to_DN(self, copy=False):
-        """Converts data and uncertainty to data number (DN).
+        """Converts data and uncertainty attributes to data number (DN).
 
         Parameters
         ----------
@@ -109,7 +158,7 @@ class IRISSpectrogramSequence(SpectrogramSequence):
 
         """
         converted_data_list = _convert_iris_sequence(self, "DN")
-        if copy:
+        if copy is True:
             return IRISSpectrogramSequence(
                 converted_data_list, self._common_axis, self.raster_positions_per_scan,
                 self.first_exposure_raster_position, meta=self.meta)
@@ -132,13 +181,13 @@ class IRISSpectrogramSequence(SpectrogramSequence):
             Default=False
 
         """
-        if undo:
+        if undo is True:
             correction_function = _uncalculate_exposure_time_correction
         else:
             correction_function = _calculate_exposure_time_correction
         converted_data_list = _apply_or_undo_exposure_time_correction(
             self, correction_function)
-        if copy:
+        if copy is True:
             IRISSpectrogramSequence(
                 converted_cube_list, self._common_axis, self.raster_positions_per_scan,
                 self.first_exposure_raster_position, meta=self.meta)
@@ -202,6 +251,13 @@ def _extra_coords_to_input_format(extra_coords):
     ----------
     extra_coords: dict
         An NDCube._extra_coords instance.
+
+
+    Returns
+    -------
+    input_format: `list`
+        Infomation on extra coords in format required by `ndcube.NDCube.__init__`.
+
     """
     return [(key, extra_coords[key]["axis"], extra_coords[key]["value"]) for key in extra_coords]
 

--- a/irispy/spectrograph.py
+++ b/irispy/spectrograph.py
@@ -19,7 +19,6 @@ from irispy import iris_tools
 
 __all__ = ['IRISSpectrograph']
 
-
 class IRISSpectrograph(object):
     """
     An object to hold data from multiple IRIS raster scans.


### PR DESCRIPTION
This PR creates a new class, ```IRISSpectrogramSequence```, which, in addition to the functionality provided to it by its parent class, ```SpectrogramSequence```, supplies functionality to do the following:
* Convert the data and uncertainty in a ```SpectrogramSequence``` between DN and counts.
* Apply and undo exposure time correction to both data and uncertainty.

In addition to introducing this new class, this PR updates the ```IRISSpectrograph``` object in the following ways:
* The use of ```SpectrogramSequence``` is replaced with ```IRISSpectrogramSequence```.
* Uncertainty on the intensity data is calculated when reading in each file during the initialization of the ```IRISSpectrograph``` and then included in the initialization of that file's ```NDCube```.

This PR makes a start in addressing Issue #25.