### PR TITLE
Fix bug in IRISSpectrogramCubeSequence repr string.

### DIFF
--- a/irispy/spectrograph.py
+++ b/irispy/spectrograph.py
@@ -139,7 +139,7 @@ Sequence period: {inst_start} -- {inst_end}
 Sequence Shape: {seq_shape}
 Axis Types: {axis_types}
 
-""".format(obs_repr=_produce_obs_repr_string(self.meta),
+""".format(obs_repr=_produce_obs_repr_string(self.data[0].meta),
            inst_start=self[0].extra_coords["time"]["value"][0],
            inst_end=self[-1].extra_coords["time"]["value"][-1],
            seq_shape=self.dimensions, axis_types=self.world_axis_physical_types)


### PR DESCRIPTION
This is intended as a short/medium term fix to a bug which occurred because the ```IRISSpectrogramCubeSequence.__repr__``` was looking for metadata common to the sub-cubes in the sequence level meta attribute, ```IRISSpectrogramCubeSequence.meta```.  However, these currently reside in the cube-level metas, ```IRISSpectrogramCube.meta```.  Therefore, ```None``` values were being printed as part of the ```__repr__``` string.

The fix involves checking the first ```IRISSpectrogramCube``` in the sequence under the assumption that the desired meta is indeed common between the sub-```IRISSpectrogramCube```s.

Issue #120 outlines a more satisfactory possible long term solution.  But until then, this fix will suffice for the vast majority of cases.