### PR TITLE
Add apply exposure time correction method to IRISMapCubeSequence

### DIFF
--- a/irispy/new_sji.py
+++ b/irispy/new_sji.py
@@ -286,6 +286,42 @@ Axis Types:\t\t {axis_types}
     def world_axis_physical_types(self):
         return self.cube_like_world_axis_physical_types
 
+def apply_exposure_time_correction(self, undo=False, force=False):
+        """
+        Applies or undoes exposure time correction to data and uncertainty and adjusts unit.
+
+        Correction is only applied (undone) if the object's unit doesn't (does)
+        already include inverse time.  This can be overridden so that correction
+        is applied (undone) regardless of unit by setting force=True.
+
+        Parameters
+        ----------
+        undo: `bool`
+            If False, exposure time correction is applied.
+            If True, exposure time correction is removed.
+            Default=False
+
+        force: `bool`
+            If not True, applies (undoes) exposure time correction only if unit
+            doesn't (does) already include inverse time.
+            If True, correction is applied (undone) regardless of unit.  Unit is still
+            adjusted accordingly.
+
+        Returns
+        -------
+        result: `None` or `IRISMapCube`
+            If copy=False, the original IRISMapCube is modified with the exposure
+            time correction applied (undone).
+            If copy=True, a new IRISMapCube is returned with the correction
+            applied (undone).
+
+        """
+        new_seq = []
+        for cube in self.data:
+            new_seq.append(cube.apply_exposure_time_correction(undo=undo, force=force))
+        return IRISMapCubeSequence(data_list=new_seq, meta=self.meta,
+                                   common_axis=self._common_axis)
+
 
 def read_iris_sji_level2_fits(filenames, memmap=False):
     """

--- a/irispy/new_sji.py
+++ b/irispy/new_sji.py
@@ -313,7 +313,6 @@ Axis Types:\t\t {axis_types}
             applied (undone).
 
         """
-        corrected_data = []
         corrected_data = [cube.apply_exposure_time_correction(undo=undo, force=force)
                           for cube in self.data]
         if copy is True:

--- a/irispy/new_sji.py
+++ b/irispy/new_sji.py
@@ -286,7 +286,7 @@ Axis Types:\t\t {axis_types}
     def world_axis_physical_types(self):
         return self.cube_like_world_axis_physical_types
 
-def apply_exposure_time_correction(self, undo=False, force=False):
+    def apply_exposure_time_correction(self, undo=False, force=False):
         """
         Applies or undoes exposure time correction to data and uncertainty and adjusts unit.
 

--- a/irispy/new_sji.py
+++ b/irispy/new_sji.py
@@ -157,11 +157,6 @@ class IRISMapCube(NDCube):
             If True, exposure time correction is removed.
             Default=False
 
-        copy: `bool`
-            If True a new instance with the converted data values is returned.
-            If False, the current instance is overwritten.
-            Default=False
-
         force: `bool`
             If not True, applies (undoes) exposure time correction only if unit
             doesn't (does) already include inverse time.
@@ -170,11 +165,8 @@ class IRISMapCube(NDCube):
 
         Returns
         -------
-        result: `None` or `IRISMapCube`
-            If copy=False, the original IRISMapCube is modified with the exposure
-            time correction applied (undone).
-            If copy=True, a new IRISMapCube is returned with the correction
-            applied (undone).
+        result: `IRISMapCube`
+            A new IRISMapCube is returned with the correction applied (undone).
 
         """
         # Raise an error if this method is called while memmap is used
@@ -286,7 +278,7 @@ Axis Types:\t\t {axis_types}
     def world_axis_physical_types(self):
         return self.cube_like_world_axis_physical_types
 
-    def apply_exposure_time_correction(self, undo=False, force=False):
+    def apply_exposure_time_correction(self, undo=False, copy=False, force=False):
         """
         Applies or undoes exposure time correction to data and uncertainty and adjusts unit.
 
@@ -301,6 +293,11 @@ Axis Types:\t\t {axis_types}
             If True, exposure time correction is removed.
             Default=False
 
+        copy: `bool`
+            If True a new instance with the converted data values is returned.
+            If False, the current instance is overwritten.
+            Default=False
+
         force: `bool`
             If not True, applies (undoes) exposure time correction only if unit
             doesn't (does) already include inverse time.
@@ -309,19 +306,21 @@ Axis Types:\t\t {axis_types}
 
         Returns
         -------
-        result: `None` or `IRISMapCube`
-            If copy=False, the original IRISMapCube is modified with the exposure
+        result: `IRISMapCubeSequence`
+            If copy=False, the original IRISMapCubeSequence is modified with the exposure
             time correction applied (undone).
-            If copy=True, a new IRISMapCube is returned with the correction
+            If copy=True, a new IRISMapCubeSequence is returned with the correction
             applied (undone).
 
         """
-        new_seq = []
-        for cube in self.data:
-            new_seq.append(cube.apply_exposure_time_correction(undo=undo, force=force))
-        return IRISMapCubeSequence(data_list=new_seq, meta=self.meta,
-                                   common_axis=self._common_axis)
-
+        corrected_data = []
+        corrected_data = [cube.apply_exposure_time_correction(undo=undo, force=force)
+                          for cube in self.data]
+        if copy is True:
+            return IRISMapCubeSequence(data_list=corrected_data, meta=self.meta,
+                                       common_axis=self._common_axis)
+        else:
+            self.data = corrected_data
 
 def read_iris_sji_level2_fits(filenames, memmap=False):
     """


### PR DESCRIPTION
Creating an exposure time correction method to `IRISMapCubeSequence`.

Some tests must be done before merging.