### PR TITLE
Allow only one OBSID and one passband per IRISMapCubeSequence

### DIFF
--- a/irispy/sji.py
+++ b/irispy/sji.py
@@ -253,10 +253,6 @@ class IRISMapCubeSequence(NDCubeSequence):
 
     """
     def __init__(self, data_list, meta=None, common_axis=0):
-        # Check that all SJI data are coming from the same OBS ID.
-        if np.any([cube.meta["OBSID"] != data_list[0].meta["OBSID"] for cube in data_list]):
-            raise ValueError("Constituent IRISMapCube objects must have same "
-                             "value of 'OBSID' in its meta.")
         # Initialize IRISMapCubeSequence.
         super().__init__(data_list, meta=meta, common_axis=common_axis)
 
@@ -534,6 +530,14 @@ def read_iris_sji_level2_fits(filenames, memmap=False):
     if len(filenames) == 1:
         return list_of_cubes[0]
     else:
+        # In Sequence, all cubes must have the same Observation Identification.
+        if np.any([cube.meta["OBSID"] != list_of_cubes[0].meta["OBSID"]
+                   for cube in list_of_cubes]):
+            raise ValueError("Inputed files must have the same Observation Identification")
+        # In Sequence, all cubes must have the same passband.
+        if np.any([cube.meta["TWAVE1"] != list_of_cubes[0].meta["TWAVE1"]
+                   for cube in list_of_cubes]):
+            raise ValueError("Inputed files must have the same passband")
         return IRISMapCubeSequence(list_of_cubes, meta=meta, common_axis=0)
 
 

--- a/irispy/sji.py
+++ b/irispy/sji.py
@@ -11,10 +11,8 @@ import astropy.units as u
 from astropy.wcs import WCS
 from sunpy.time import parse_time
 from sunpy.map import GenericMap
-from scipy import ndimage
 from ndcube import NDCube
 from ndcube.utils.cube import convert_extra_coords_dict_to_input_format
-from ndcube import utils
 from ndcube.ndcube_sequence import NDCubeSequence
 
 from irispy import iris_tools

--- a/irispy/tests/test_new_sji.py
+++ b/irispy/tests/test_new_sji.py
@@ -6,10 +6,9 @@ import pytest
 import numpy as np
 from astropy import units as u
 from ndcube.utils.wcs import WCS
-from ndcube.tests.helpers import assert_cubes_equal, assert_cubesequences_equal
 
 from irispy import iris_tools
-from irispy.new_sji import IRISMapCube, IRISMapCubeSequence
+from irispy.sji import IRISMapCube, IRISMapCubeSequence
 
 # Sample data for IRISMapCube tests
 data = np.array([[[1, 2, 3, 4], [2, 4, 5, 3], [0, 1, 2, 3]],
@@ -115,12 +114,9 @@ cube_dust = IRISMapCube(data_dust, wcs, uncertainty=uncertainty, mask=mask_dust,
 # Sample of data for IRISMapCubeSequence tests:
 
 meta_1 = {"OBSID":1}
-meta_2 = {"OBSID":2}
 
 cube_seq= IRISMapCube(data, wcs, uncertainty=uncertainty, mask=mask_cube, unit=unit,
                       meta=meta_1, extra_coords=extra_coords, scaled=scaled_T)
-cube_seq_2= IRISMapCube(data, wcs, uncertainty=uncertainty, mask=mask_cube, unit=unit,
-                        meta=meta_2, extra_coords=extra_coords, scaled=scaled_T)
 cube_seq_per_s= IRISMapCube(data/2, wcs, uncertainty=uncertainty, mask=mask_cube, unit=unit/u.s,
                             meta=meta_1, extra_coords=extra_coords, scaled=scaled_T)
 cube_seq_per_s_per_s= IRISMapCube(data/2/2, wcs, uncertainty=uncertainty, mask=mask_cube,
@@ -204,12 +200,6 @@ def test_IRISMapCubeSequence_apply_exposure_time_correction(test_input, undo, co
     for i in range(len(output_sequence.data)):
         np.testing.assert_array_equal(output_sequence.data[i].data, expected.data[i].data)
 
-@pytest.mark.parametrize("test_input, cubes", [
-    (ValueError, (cube_seq, cube_seq_2))])
-def test_IRISMapCubeSequence_initializaton(test_input, cubes):
-    with pytest.raises(test_input):
-        IRISMapCubeSequence(data_list=[cubes[0], cubes[1]], meta=meta_1, common_axis=0)
-        
 @pytest.mark.parametrize("test_input,expected", [
     (seq_dust, dust_mask_expected)])
 def test_IRISMapCubeSequence_apply_dust_mask(test_input, expected):


### PR DESCRIPTION
IRISMapCubeSequence must store data from the same OBSID and passband.

The check is written inside the reading function.