### PR TITLE
Switch to astropy time and make SJI and SP more consistent

### DIFF
--- a/irispy/sji.py
+++ b/irispy/sji.py
@@ -2,14 +2,13 @@
 This module provides movie tools for level 2 IRIS SJI fits file
 '''
 
-from datetime import timedelta
 import warnings
 
 import numpy as np
 from astropy.io import fits
 import astropy.units as u
 from astropy.wcs import WCS
-from sunpy.time import parse_time
+from astropy.time import Time, TimeDelta
 from sunpy.map import GenericMap
 from ndcube import NDCube
 from ndcube.utils.cube import convert_extra_coords_dict_to_input_format
@@ -99,21 +98,20 @@ class IRISMapCube(NDCube):
                          copy=copy, missing_axes=missing_axes)
 
     def __repr__(self):
+        roll = self.meta.get("SAT_ROT", None)
         # Conversion of the start date of OBS
         startobs = self.meta.get("STARTOBS", None)
-        startobs = startobs.isoformat() if startobs else None
+        startobs = startobs.isot if startobs else None
         # Conversion of the end date of OBS
         endobs = self.meta.get("ENDOBS", None)
-        endobs = endobs.isoformat() if endobs else None
+        endobs = endobs.isot if endobs else None
         # Conversion of the instance start and end of OBS
-        if isinstance(self.extra_coords["TIME"]["value"], np.ndarray):
-            instance_start = self.extra_coords["TIME"]["value"][0]
-            instance_end = self.extra_coords["TIME"]["value"][-1]
+        if isinstance(self.extra_coords["time"]["value"], Time):
+            instance_start = self.extra_coords["time"]["value"].min().isot
+            instance_end = self.extra_coords["time"]["value"].max().isot
         else:
-            instance_start = self.extra_coords["TIME"]["value"]
-            instance_end = self.extra_coords["TIME"]["value"]
-        instance_start = instance_start.isoformat() if instance_start else None
-        instance_end = instance_end.isoformat() if instance_end else None
+            instance_start = None
+            instance_end = None
         # Representation of IRISMapCube object
         return (
             """
@@ -126,6 +124,7 @@ class IRISMapCube(NDCube):
     Obs. End:\t\t\t {endobs}
     Instance Start:\t\t {instance_start}
     Instance End:\t\t {instance_end}
+    Roll:\t\t\t {roll}
     Total Frames in Obs.:\t {frame_num}
     IRIS Obs. id:\t\t {obs_id}
     IRIS Obs. Description:\t {obs_desc}
@@ -138,6 +137,7 @@ class IRISMapCube(NDCube):
                endobs=endobs,
                instance_start=instance_start,
                instance_end=instance_end,
+               roll=roll,
                frame_num=self.meta.get("NBFRAMES", None),
                obs_id=self.meta.get('OBSID', None),
                obs_desc=self.meta.get('OBS_DESC', None),
@@ -183,8 +183,8 @@ class IRISMapCube(NDCube):
             raise ValueError("This method is not available as you are using memmap")
         # Get exposure time in seconds and change array's shape so that
         # it can be broadcast with data and uncertainty arrays.
-        exposure_time_s = u.Quantity(self.extra_coords["EXPOSURE TIME"]["value"], unit='s').value
-        if not np.isscalar(self.extra_coords["EXPOSURE TIME"]["value"]):
+        exposure_time_s = u.Quantity(self.extra_coords["exposure time"]["value"], unit='s').value
+        if not np.isscalar(self.extra_coords["exposure time"]["value"]):
             if self.data.ndim == 1:
                 pass
             elif self.data.ndim == 2:
@@ -262,18 +262,19 @@ class IRISMapCubeSequence(NDCubeSequence):
         super().__init__(data_list, meta=meta, common_axis=common_axis)
 
     def __repr__(self):
+        roll = self.meta.get("SAT_ROT", None)
         # Conversion of the start date of OBS
         startobs = self.meta.get("STARTOBS", None)
-        startobs = startobs.isoformat() if startobs else None
+        startobs = startobs.isot if startobs else None
         # Conversion of the end date of OBS
         endobs = self.meta.get("ENDOBS", None)
-        endobs = endobs.isoformat() if endobs else None
+        endobs = endobs.isot if endobs else None
         # Conversion of the instance start of OBS
-        instance_start = self[0].extra_coords["TIME"]["value"]
-        instance_start = instance_start.isoformat() if instance_start else None
+        instance_start = self[0].extra_coords["time"]["value"]
+        instance_start = instance_start.isot if instance_start else None
         # Conversion of the instance end of OBS
-        instance_end = self[-1].extra_coords["TIME"]["value"]
-        instance_end = instance_end.isoformat() if instance_end else None
+        instance_end = self[-1].extra_coords["time"]["value"]
+        instance_end = instance_end.isot if instance_end else None
         # Representation of IRISMapCube object
         return """
 IRISMapCubeSequence
@@ -287,6 +288,7 @@ OBS period:\t\t {obs_start} -- {obs_end}
 
 Sequence period:\t {inst_start} -- {inst_end}
 Sequence Shape:\t\t {seq_shape}
+Roll:\t\t\t {roll}
 Axis Types:\t\t {axis_types}
 
 """.format(obs=self.meta.get('TELESCOP', None),
@@ -298,6 +300,7 @@ Axis Types:\t\t {axis_types}
            inst_start=instance_start,
            inst_end=instance_end,
            seq_shape=self.dimensions,
+           roll=roll,
            axis_types=self.world_axis_physical_types)
 
     def __getitem__(self, item):
@@ -502,9 +505,8 @@ def read_iris_sji_level2_fits(filenames, memmap=False):
         # Derive exposure time from detector.
         exposure_times = hdulist[1].data[:, hdulist[1].header["EXPTIMES"]]
         # Derive extra coordinates for NDCube from fits file.
-        times = np.array([parse_time(hdulist[0].header["STARTOBS"])
-                          + timedelta(seconds=s)
-                          for s in hdulist[1].data[:, hdulist[1].header["TIME"]]])
+        times = (Time(hdulist[0].header["STARTOBS"]) +
+                 TimeDelta(hdulist[1].data[:, hdulist[1].header["TIME"]], format='sec'))
         pztx = hdulist[1].data[:, hdulist[1].header["PZTX"]] * u.arcsec
         pzty = hdulist[1].data[:, hdulist[1].header["PZTY"]] * u.arcsec
         xcenix = hdulist[1].data[:, hdulist[1].header["XCENIX"]] * u.arcsec
@@ -513,29 +515,31 @@ def read_iris_sji_level2_fits(filenames, memmap=False):
         ophaseix = hdulist[1].data[:, hdulist[1].header["OPHASEIX"]]
         slit_pos_x = hdulist[1].data[:, hdulist[1].header["SLTPX1IX"]]
         slit_pos_y = hdulist[1].data[:, hdulist[1].header["SLTPX2IX"]]
-        extra_coords = [('TIME', 0, times), ("PZTX", 0, pztx), ("PZTY", 0, pzty),
-                        ("XCENIX", 0, xcenix), ("YCENIX", 0, ycenix),
-                        ("OBS_VRIX", 0, obs_vrix), ("OPHASEIX", 0, ophaseix),
-                        ("EXPOSURE TIME", 0, exposure_times),
-                        ("SLIT X POSITION", 0, slit_pos_x*u.pix),
-                        ("SLIT Y POSITION", 0, slit_pos_y*u.pix)]
+        extra_coords = [('time', 0, times), ("pztx", 0, pztx), ("pzty", 0, pzty),
+                        ("xcenix", 0, xcenix), ("ycenix", 0, ycenix),
+                        ("obs_vrix", 0, obs_vrix), ("ophaseix", 0, ophaseix),
+                        ("exposure time", 0, exposure_times),
+                        ("slit x position", 0, slit_pos_x * u.pix),
+                        ("slit y position", 0, slit_pos_y * u.pix)]
         # Extraction of meta for NDCube from fits file.
         startobs = hdulist[0].header.get('STARTOBS', None)
-        startobs = parse_time(startobs) if startobs else None
+        startobs = Time(startobs) if startobs else None
         endobs = hdulist[0].header.get('ENDOBS', None)
-        endobs = parse_time(endobs) if endobs else None
+        endobs = Time(endobs) if endobs else None
         meta = {'TELESCOP': hdulist[0].header.get('TELESCOP', None),
                 'INSTRUME': hdulist[0].header.get('INSTRUME', None),
+                'DATA_LEV': hdulist[0].header.get('DATA_LEV', None),
                 'TWAVE1': hdulist[0].header.get('TWAVE1', None),
+                'OBSID': hdulist[0].header.get('OBSID', None),
                 'STARTOBS': startobs,
                 'ENDOBS': endobs,
+                'SAT_ROT': hdulist[0].header['SAT_ROT'] * u.deg,
                 'NBFRAMES': hdulist[0].data.shape[0],
-                'OBSID': hdulist[0].header.get('OBSID', None),
                 'OBS_DESC': hdulist[0].header.get('OBS_DESC', None),
-                'FOVX': hdulist[0].header.get('FOVX', None),
-                'FOVY': hdulist[0].header.get('FOVY', None),
-                'XCEN': hdulist[0].header.get('XCEN', None),
-                'YCEN': hdulist[0].header.get('YCEN', None)}
+                'FOVX': hdulist[0].header['FOVX'] * u.arcsec,
+                'FOVY': hdulist[0].header['FOVY'] * u.arcsec,
+                'XCEN': hdulist[0].header['XCEN'] * u.arcsec,
+                'YCEN': hdulist[0].header['YCEN'] * u.arcsec}
         list_of_cubes.append(IRISMapCube(data_nan_masked, wcs, uncertainty=uncertainty,
                                          unit=unit, meta=meta, mask=mask,
                                          extra_coords=extra_coords, scaled=scaled))

--- a/irispy/tests/test_sji.py
+++ b/irispy/tests/test_sji.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 # """Tests for functions in sji.py"""
-import datetime
-
 import pytest
 import numpy as np
 from astropy import units as u
+from astropy.time import Time, TimeDelta
 from ndcube.utils.wcs import WCS
 
 from irispy import iris_tools
@@ -55,12 +54,11 @@ uncertainty_2D = np.sqrt(data_2D)
 uncertainty_1D = np.sqrt(data_1D)
 uncertainty_4D = np.sqrt(data_4D)
 
-times = np.array([datetime.datetime(2014, 12, 11, 19, 39, 0, 480000),
-                  datetime.datetime(2014, 12, 11, 19, 43, 7, 600000)])
+times = Time(['2014-12-11T19:39:00.48', '2014-12-11T19:43:07.6'])
 
 exposure_times = 2*np.ones((2), float)
-extra_coords = [('TIME', 0, times),
-                ('EXPOSURE TIME', 0, exposure_times)]
+extra_coords = [('time', 0, times),
+                ('exposure time', 0, exposure_times)]
 
 scaled_T = True
 scaled_F = False
@@ -97,12 +95,11 @@ dust_mask_expected = np.array(
 
 uncertainty = 1
 
-times = np.array([datetime.datetime(2014, 12, 11, 19, 39, 0, 480000),
-                  datetime.datetime(2014, 12, 11, 19, 43, 7, 600000)])
+times = Time(['2014-12-11T19:39:00.48', '2014-12-11T19:43:07.6'])
 
 exposure_times = 2*np.ones((2), float)
-extra_coords = [('TIME', 0, times),
-                ('EXPOSURE TIME', 0, exposure_times)]
+extra_coords = [('time', 0, times),
+                ('exposure time', 0, exposure_times)]
 
 scaled_T = True
 

--- a/irispy/tests/test_spectrograph.py
+++ b/irispy/tests/test_spectrograph.py
@@ -4,12 +4,12 @@
 import os.path
 import pytest
 import copy
-import datetime
 
 import numpy as np
 import astropy.wcs as wcs
 from astropy.io import fits
 import astropy.units as u
+from astropy.time import Time, TimeDelta
 from ndcube.utils.wcs import WCS
 from ndcube.tests.helpers import assert_cubes_equal, assert_cubesequences_equal
 
@@ -50,13 +50,12 @@ meta0 = {"detector type": "FUV", "OBSID": 1, "spectral window": "C II 1336"}
 
 # Define sample extra coords
 extra_coords0 = [("time", 0,
-                  np.array([datetime.datetime(2017, 1, 1)+datetime.timedelta(seconds=i)
-                             for i in range(time_dim_len)])),
-                ("exposure time", 0, EXPOSURE_TIME)]
+                  Time('2017-01-01') + TimeDelta(np.arange(time_dim_len), format='sec')),
+                 ("exposure time", 0, EXPOSURE_TIME)]
 extra_coords1 = [("time", 0,
-                  np.array([datetime.datetime(2017, 1, 1)+datetime.timedelta(seconds=i)
-                             for i in range(time_dim_len, time_dim_len*2)])),
-                ("exposure time", 0, EXPOSURE_TIME)]
+                  (Time('2017-01-01') +
+                   TimeDelta(np.arange(time_dim_len, time_dim_len*2), format='sec'))),
+                 ("exposure time", 0, EXPOSURE_TIME)]
 
 # Define IRISSpectrogramCubes in various units.
 spectrogram_DN0 = IRISSpectrogramCube(


### PR DESCRIPTION
Currently, the `__repr__` of SJI is giving an exception because it calls `isoformat()`, while NDCube and SunPy now use `astropy.time.Time`. At the same time, `extra_coords` for both SJI and SP are now being populated with an object array of `Time` objects, which is rather useless (e.g. for time deltas). This PR fixes that, removes all calls to `isoformat()`, populates `extra_coords` with an `Time` object that is an array.

It also improves on some consistency between SJI and SP, fixes #113 (ended up going all lowercase after a few attempts at using it proved a significant burden to go uppercase). Also contributed to #100 by adding roll to `meta` of the spectrograph, and added roll to `__repr__` of both spectrograph and SJI instances, since it is such an important keyword.